### PR TITLE
Docker: Ensure proper port mapping to container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   web:
     build: .
     ports:
-     - "8080:8080"
+     - "8080:80"
     environment:
      - MONGODB_URI=mongodb://mongo:27017/test 
     links:
@@ -15,4 +15,3 @@ services:
     volumes:
      - .:/starter
      - /starter/node_modules
-     


### PR DESCRIPTION
Quick tweak to be more docker-friendly when using `docker-compose up` to launch.

The app defaults to port 80 (per b10bd8b) so best to ensure the correct mapping is performed in the `docker-compose.yml` file 😄 